### PR TITLE
Lua 5.3 compatibility

### DIFF
--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -149,7 +149,7 @@ function show_page_elements(parent)
       local color = "1 g"
       local rectangle = node.new("whatsit","pdf_literal")
       if head.penalty < 10000 then
-        color = string.format("%d g", 1 - head.penalty / 10000)
+        color = string.format("%d g", 1 - math.floor(head.penalty / 10000))
       end
       rectangle.data = string.format("q %s 0 w 0 0 1 1 re B Q",color)
       parent.list = node.insert_before(parent.list,head,rectangle)


### PR DESCRIPTION
The upcoming release of TeX Live 2018 will switch from Lua 5.2 to Lua 5.3 (at least pretest does).  This new release introduces a separation between integer and floating point types (a.k.a. `number`).  Values of type `number` can no longer be formatted with the `%d` format string and have to be converted to integers first.  While Lua 5.3 introduces integer division via the double-slash operator `a // b`, it is better to use `math.floor(a / b)` to maintain backwards compatibility with Lua 5.2.