### PR TITLE
a start for #11 and add rectangles around glyphs

### DIFF
--- a/lua-visual-debug-keys.lua
+++ b/lua-visual-debug-keys.lua
@@ -55,7 +55,9 @@ end
 
 local function onlyglyphs()
     for _,v in pairs(params) do
-        v.show = false
+        if v.show then 
+            v.show = false
+        end
     end
     params.glyph.show = true
 end
@@ -69,6 +71,7 @@ local outer_keys = {
     kern = {scanner = function() return true end, func = set_params},
     penalty = {scanner = function() return true end, func = set_params},
     glyph = {scanner = function() return true end, func = set_params},
+    opacity = {scanner = scan_string},
     onlyglyphs = {default = true, func = onlyglyphs}
 }
 
@@ -80,5 +83,8 @@ do
   local luafnalloc = luatexbase and luatexbase.new_luafunction 
     and luatexbase.new_luafunction('lvdset') or #function_table + 1
   token.set_lua('lvdset', luafnalloc)
-  function_table[luafnalloc] = function() return process_keys(outer_keys) end
+  function_table[luafnalloc] = function() 
+      local vals = process_keys(outer_keys)
+      params.opacity = vals.opacity or params.opacity
+  end
 end

--- a/lua-visual-debug-keys.lua
+++ b/lua-visual-debug-keys.lua
@@ -1,0 +1,84 @@
+local lvd = require('lua-visual-debug')
+local params = lvd.params
+local keyval = require('luakeyval')
+local process_keys = keyval.process
+local scan_bool = keyval.bool
+local scan_string = token.scan_string
+local scan_float = token.scan_float
+local inner_keys = {
+    hlist = {
+        show = {scanner = scan_bool},
+        color = {scanner = scan_string},
+        width = {scanner = scan_float}
+    },
+    vlist = {
+        show = {scanner = scan_bool},
+        color = {scanner = scan_string},
+        width = {scanner = scan_float}
+    },
+    rule = {
+        show = {scanner = scan_bool},
+        color = {scanner = scan_string},
+        width = {scanner = scan_float}
+    },
+    disc = {
+        show = {scanner = scan_bool},
+        color = {scanner = scan_string},
+        width = {scanner = scan_float}
+    },
+    glue = {
+        show = {scanner = scan_bool},
+    },
+    kern = {
+        show = {scanner = scan_bool},
+        negative_color = {scanner = scan_string},
+        color = {scanner = scan_string},
+        width = {scanner = scan_float}
+    },
+    penalty = {
+        show = {scanner = scan_bool},
+    },
+    glyph = {
+        show = {scanner = scan_bool},
+        color = {scanner = scan_string},
+        width = {scanner = scan_float},
+        baseline = {scanner = scan_bool}
+    },
+}
+
+local function set_params(key)
+    local vals = process_keys(inner_keys[key])
+    for k,v in pairs(vals) do
+        params[key][k] = v
+    end
+end
+
+local function onlyglyphs()
+    for _,v in pairs(params) do
+        v.show = false
+    end
+    params.glyph.show = true
+end
+
+local outer_keys = {
+    hlist = {scanner = function() return true end, func = set_params},
+    vlist = {scanner = function() return true end, func = set_params},
+    rule = {scanner = function() return true end, func = set_params},
+    disc = {scanner = function() return true end, func = set_params},
+    glue = {scanner = function() return true end, func = set_params},
+    kern = {scanner = function() return true end, func = set_params},
+    penalty = {scanner = function() return true end, func = set_params},
+    glyph = {scanner = function() return true end, func = set_params},
+    onlyglyphs = {default = true, func = onlyglyphs}
+}
+
+do
+  if token.is_defined('lvdset') then
+      texio.write_nl('log', "lua-visual-debug: redefining \\lvdset")
+  end
+  local function_table = lua.get_functions_table()
+  local luafnalloc = luatexbase and luatexbase.new_luafunction 
+    and luatexbase.new_luafunction('lvdset') or #function_table + 1
+  token.set_lua('lvdset', luafnalloc)
+  function_table[luafnalloc] = function() return process_keys(outer_keys) end
+end

--- a/lua-visual-debug-keys.lua
+++ b/lua-visual-debug-keys.lua
@@ -46,8 +46,15 @@ local inner_keys = {
     },
 }
 
+local messages = {
+    error1 = "lua-visual-debug: Wrong syntax in \\lvdset",
+    value_forbidden = 'lua-visual-debug: The key "%s" does not accept a value',
+    value_required = 'lua-visual-debug: The key "%s" requires a value',
+}
+
+
 local function set_params(key)
-    local vals = process_keys(inner_keys[key])
+    local vals = process_keys(inner_keys[key],messages)
     for k,v in pairs(vals) do
         params[key][k] = v
     end
@@ -84,7 +91,7 @@ do
     and luatexbase.new_luafunction('lvdset') or #function_table + 1
   token.set_lua('lvdset', luafnalloc)
   function_table[luafnalloc] = function() 
-      local vals = process_keys(outer_keys)
+      local vals = process_keys(outer_keys,messages)
       params.opacity = vals.opacity or params.opacity
   end
 end

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -93,8 +93,6 @@ local inner_keys = {
     },
     glue = {
         show = {scanner = scan_bool},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float}
     },
     kern = {
         show = {scanner = scan_bool},
@@ -104,8 +102,6 @@ local inner_keys = {
     },
     penalty = {
         show = {scanner = scan_bool},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float}
     },
     glyph = {
         show = {scanner = scan_bool},
@@ -119,10 +115,10 @@ local params = {
     vlist = {show = true, color = "0.1 G", width = 0.1},
     rule = {show = true, color = "1 0 0 RG 1 0 0 rg", width = 0.4},
     disc = {show = true, color = "0 0 1 RG", width = 0.3},
-    glue = {show = true, color = "", width = 0},
+    glue = {show = true},
     kern = {show = true, negative_color = "1 0 0 rg", color = "1 1 0 rg", width = 1},
-    penalty = {show = true, color = "", width = 0},
-    glyph = {show = true, color = "1 0 0 RG", width = 0.1, baseline = true},
+    penalty = {show = true},
+    glyph = {show = false, color = "1 0 0 RG", width = 0.05, baseline = true},
 }
 
 local function set_params(key)
@@ -290,8 +286,8 @@ local function show_page_elements(parent)
       if curdir[#curdir] == "rtl" then wd = wd * -1 end
       local baseline = ""
       if head.depth ~= 0 and params.glyph.baseline then
-        baseline = string.format("%g %g m %g 0 l",
-          -rule_width / 2, -rule_width / 2, wd)
+        baseline = string.format("%g %g m %g %g l",
+          -rule_width / 2, -rule_width / 2, wd, -rule_width / 2)
       end      
       rectangle.data = string.format("q %s %g w %s %g %g %g %g re s Q",
         params.glyph.color, rule_width, baseline, -rule_width / 2, -dp, wd, ht)

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -24,7 +24,7 @@
 -- There are 65782 scaled points in a PDF point
 -- Therefore we need to divide all TeX lengths by
 -- this amount to get the PDF points.
-local number_sp_in_a_pdf_point = 65782
+local number_sp_in_a_pdf_point = tex.sp('1bp')
 
 
 -- The idea is the following: at page shipout, all elements on a page are fixed.
@@ -64,6 +64,8 @@ local GLUE = node.id("glue")
 local KERN = node.id("kern")
 local PENALTY = node.id("penalty")
 local GLYPH = node.id("glyph")
+
+local running_glue_dimen = -2^30
 
 local params = {
     hlist = {show = true, color = "0.5 G", width = 0.1},
@@ -123,7 +125,7 @@ local function show_page_elements(parent)
 
     elseif head.id == RULE and params.rule.show then
       local show_rule = node.new("whatsit","pdf_literal")
-      if head.width == -1073741824 or head.height == -1073741824 or head.depth == -1073741824 then
+      if head.width == running_glue_dimen or head.height == running_glue_dimen or head.depth == running_glue_dimen then
         -- ignore for now -- these rules are stretchable
       else
         local dp = math_round( head.depth / number_sp_in_a_pdf_point  ,2)

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -82,6 +82,7 @@ local params = {
     kern = {show = true, negative_color = "1 0 0 rg", color = "1 1 0 rg", width = 1},
     penalty = {show = true},
     glyph = {show = false, color = "1 0 0 RG", width = 0.05, baseline = true},
+    opacity = ""
 }
 
 local function math_round(num, idp)
@@ -120,11 +121,11 @@ local function show_page_elements(parent)
         local factor = 1
         if curdir[#curdir] == "rtl" then factor = -1 end
         if head.id == HLIST then -- hbox
-          rectangle.data = fmt("q %s %g w %g %g %g %g re s Q", 
-            params.hlist.color, rule_width, -factor*rule_width / 2, -dp, factor*wd, ht)
+          rectangle.data = fmt("q %s %s %g w %g %g %g %g re s Q", 
+            params.opacity,params.hlist.color, rule_width, -factor*rule_width / 2, -dp, factor*wd, ht)
         else
-          rectangle.data = fmt("q %s %g w %g %g %g %g re s Q", 
-            params.vlist.color, rule_width, -factor*rule_width / 2, 0, factor*wd, -ht)
+          rectangle.data = fmt("q %s %s %g w %g %g %g %g re s Q", 
+            params.opacity,params.vlist.color, rule_width, -factor*rule_width / 2, 0, factor*wd, -ht)
         end
         head.list = insert_before(head.list,head.list,rectangle)
       end
@@ -136,16 +137,16 @@ local function show_page_elements(parent)
       else
         local dp = math_round( head.depth / number_sp_in_a_pdf_point  ,2)
         local ht = math_round( head.height / number_sp_in_a_pdf_point ,2)
-        show_rule.data =  fmt("q %s %g w 0 %g m 0 %g l S Q",
-          params.rule.color, params.rule.width, -dp, ht)
+        show_rule.data =  fmt("q %s %s %g w 0 %g m 0 %g l S Q",
+          params.opacity,params.rule.color, params.rule.width, -dp, ht)
       end
       parent.list = insert_before(parent.list,head,show_rule)
 
 
     elseif head.id == DISC and params.disc.show then
       local hyphen_marker = node.new("whatsit","pdf_literal")
-      hyphen_marker.data = fmt("q %s %g w 0 -1 m 0 0 l S Q",
-        params.disc.color, params.disc.width)
+      hyphen_marker.data = fmt("q %s %s %g w 0 -1 m 0 0 l S Q",
+        params.opacity,params.disc.color, params.disc.width)
       parent.list = insert_before(parent.list,head,hyphen_marker)
 
     elseif head.id == DIR then
@@ -193,11 +194,11 @@ local function show_page_elements(parent)
         or params.kern.color
       local k = math_round(head.kern / number_sp_in_a_pdf_point,2)
       if parent.id == HLIST then
-        rectangle.data = fmt("q %s 0 w 0 0 %g %g re B Q",
-          color, k, params.kern.width)
+        rectangle.data = fmt("q %s %s 0 w 0 0 %g %g re B Q",
+          params.opacity, color, k, params.kern.width)
       else
-        rectangle.data = fmt("q %s 0 w 0 0 %g %g re B Q",
-          color, params.kern.width, -k)
+        rectangle.data = fmt("q %s %s 0 w 0 0 %g %g re B Q",
+          params.opacity, color, params.kern.width, -k)
       end
       parent.list = insert_before(parent.list,head,rectangle)
 
@@ -224,8 +225,8 @@ local function show_page_elements(parent)
         baseline = fmt("%g %g m %g %g l",
           0, -rule_width / 2, factor*(wd-rule_width), -rule_width / 2)
       end      
-      rectangle.data = fmt("q %s %g w %s %g %g %g %g re s Q",
-        params.glyph.color, rule_width, baseline, -factor*rule_width / 2, -dp, factor*wd, ht)
+      rectangle.data = fmt("q %s %s %g w %s %g %g %g %g re s Q",
+        params.opacity, params.glyph.color, rule_width, baseline, -factor*rule_width / 2, -dp, factor*wd, ht)
       parent.list, head = insert_after(parent.list,head,rectangle)
     end
     

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -98,6 +98,7 @@ local inner_keys = {
     },
     kern = {
         show = {scanner = scan_bool},
+        negative_color = {scanner = scan_string},
         color = {scanner = scan_string},
         width = {scanner = scan_float}
     },
@@ -118,7 +119,7 @@ local params = {
     rule = {show = true, color = "1 0 0 RG 1 0 0 rg", width = 0.4},
     disc = {show = true, color = "0 0 1 RG", width = 0.3},
     glue = {show = true, color = "", width = 0},
-    kern = {show = true, color = "", width = 0},
+    kern = {show = true, negative_color = "1 0 0 rg", color = "1 1 0 rg", width = 1},
     penalty = {show = true, color = "", width = 0},
     glyph = {show = true, color = "1 0 0 RG", width = 0.1},
 }
@@ -257,13 +258,15 @@ local function show_page_elements(parent)
 
     elseif head.id == KERN and params.kern.show then
       local rectangle = node.new("whatsit","pdf_literal")
-      local color = "1 1 0 rg"
-      if head.kern < 0 then color = "1 0 0 rg" end
+      local color = head.kern < 0 and params.kern.negative_color
+        or params.kern.color
       local k = math_round(head.kern / number_sp_in_a_pdf_point,2)
       if parent.id == HLIST then
-        rectangle.data = string.format("q %s 0 w 0 0 %g 1 re B Q",color, k )
+        rectangle.data = string.format("q %s 0 w 0 0 %g %g re B Q",
+          color, k, params.kern.width)
       else
-        rectangle.data = string.format("q %s 0 w 0 0  1 %g re B Q",color, -k )
+        rectangle.data = string.format("q %s 0 w 0 0 %g %g re B Q",
+          color, params.kern.width, -k)
       end
       parent.list = node.insert_before(parent.list,head,rectangle)
 

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -81,7 +81,7 @@ local params = {
     glue = {show = true},
     kern = {show = true, negative_color = "1 0 0 rg", color = "1 1 0 rg", width = 1},
     penalty = {show = true},
-    glyph = {show = false, color = "1 0 0 RG", width = 0.05, baseline = true},
+    glyph = {show = false, color = "1 0 0 RG", width = 0.1, baseline = true},
     opacity = ""
 }
 

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -102,20 +102,21 @@ local function show_page_elements(parent)
       local boxtype = node.type(head.id)
       local rule_width = params[boxtype].width
       local wd = math_round(head.width                  / number_sp_in_a_pdf_point - rule_width     ,2)
-      local ht = math_round((head.height + head.depth)  / number_sp_in_a_pdf_point - rule_width     ,2)
+      local ht = math_round((head.height + head.depth)  / number_sp_in_a_pdf_point - rule_width / 2 ,2)
       local dp = math_round(head.depth                  / number_sp_in_a_pdf_point - rule_width / 2 ,2)
 
       -- recurse into the contents of the box
       show_page_elements(head)
       if params[boxtype].show then
         local rectangle = node.new("whatsit","pdf_literal")
-        if curdir[#curdir] == "rtl" then wd = wd * -1 end
+        local factor = 1
+        if curdir[#curdir] == "rtl" then factor = -1 end
         if head.id == HLIST then -- hbox
           rectangle.data = string.format("q %s %g w %g %g %g %g re s Q", 
-            params.hlist.color, rule_width, -rule_width / 2, -dp, wd, ht)
+            params.hlist.color, rule_width, -factor*rule_width / 2, -dp, factor*wd, ht)
         else
           rectangle.data = string.format("q %s %g w %g %g %g %g re s Q", 
-            params.vlist.color, rule_width, -rule_width / 2, 0, wd, -ht)
+            params.vlist.color, rule_width, -factor*rule_width / 2, 0, factor*wd, -ht)
         end
         head.list = node.insert_before(head.list,head.list,rectangle)
       end
@@ -204,18 +205,19 @@ local function show_page_elements(parent)
     
     elseif head.id == GLYPH and params.glyph.show then
       local rule_width = params.glyph.width
-      local wd = -math_round(head.width                  / number_sp_in_a_pdf_point - rule_width     ,2)
-      local ht = math_round((head.height + head.depth)  / number_sp_in_a_pdf_point - rule_width     ,2)
+      local wd = -math_round(head.width                 / number_sp_in_a_pdf_point - rule_width     ,2)
+      local ht = math_round((head.height + head.depth)  / number_sp_in_a_pdf_point - rule_width / 2 ,2)
       local dp = math_round(head.depth                  / number_sp_in_a_pdf_point - rule_width / 2 ,2)
       local rectangle = node.new("whatsit", "pdf_literal")
-      if curdir[#curdir] == "rtl" then wd = wd * -1 end
+      local factor = 1
+      if curdir[#curdir] == "rtl" then factor = -1 end
       local baseline = ""
       if head.depth ~= 0 and params.glyph.baseline then
         baseline = string.format("%g %g m %g %g l",
-          -rule_width / 2, -rule_width / 2, wd, -rule_width / 2)
+          0, -rule_width / 2, factor*(wd-rule_width), -rule_width / 2)
       end      
       rectangle.data = string.format("q %s %g w %s %g %g %g %g re s Q",
-        params.glyph.color, rule_width, baseline, -rule_width / 2, -dp, wd, ht)
+        params.glyph.color, rule_width, baseline, -factor*rule_width / 2, -dp, factor*wd, ht)
       parent.list = node.insert_after(parent.list,head,rectangle)
       head = head.next
     end

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -128,6 +128,13 @@ local function set_params(key)
     end
 end
 
+local function onlyglyphs()
+    for _,v in pairs(params) do
+        v.show = false
+    end
+    params.glyph.show = true
+end
+
 local outer_keys = {
     hlist = {scanner = function() return true end, func = set_params},
     vlist = {scanner = function() return true end, func = set_params},
@@ -137,6 +144,7 @@ local outer_keys = {
     kern = {scanner = function() return true end, func = set_params},
     penalty = {scanner = function() return true end, func = set_params},
     glyph = {scanner = function() return true end, func = set_params},
+    onlyglyphs = {default = true, func = onlyglyphs}
 }
 
 do

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -76,7 +76,7 @@ local running_glue_dimen = -2^30
 local params = {
     hlist = {show = true, color = "0.5 G", width = 0.1},
     vlist = {show = true, color = "0.1 G", width = 0.1},
-    rule = {show = true, color = "1 0 0 RG 1 0 0 rg", width = 0.4},
+    rule = {show = true, color = "1 0 0 RG", width = 0.4},
     disc = {show = true, color = "0 0 1 RG", width = 0.3},
     glue = {show = true},
     kern = {show = true, negative_color = "1 0 0 rg", color = "1 1 0 rg", width = 1},

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -180,28 +180,27 @@ local function show_page_elements(parent)
     elseif head.dir == "TRT" then
       table.insert(curdir,"rtl") has_dir=true
     end
-    if (head.id == HLIST and params.hlist.show) 
-      or (head.id == VLIST and params.vlist.show) then
-
-      local rule_width = (head.id == HLIST) and params.hlist.width
-        or params.vlist.width
+    if head.id == HLIST or head.id == VLIST then
+      local boxtype = node.type(head.id)
+      local rule_width = params[boxtype].width
       local wd = math_round(head.width                  / number_sp_in_a_pdf_point - rule_width     ,2)
       local ht = math_round((head.height + head.depth)  / number_sp_in_a_pdf_point - rule_width     ,2)
       local dp = math_round(head.depth                  / number_sp_in_a_pdf_point - rule_width / 2 ,2)
 
       -- recurse into the contents of the box
       show_page_elements(head)
-      local rectangle = node.new("whatsit","pdf_literal")
-      if curdir[#curdir] == "rtl" then wd = wd * -1 end
-      if head.id == HLIST then -- hbox
-        rectangle.data = string.format("q %s %g w %g %g %g %g re s Q", 
-          params.hlist.color, rule_width, -rule_width / 2, -dp, wd, ht)
-      else
-        rectangle.data = string.format("q %s %g w %g %g %g %g re s Q", 
-          params.vlist.color, rule_width, -rule_width / 2, 0, wd, -ht)
+      if params[boxtype].show then
+        local rectangle = node.new("whatsit","pdf_literal")
+        if curdir[#curdir] == "rtl" then wd = wd * -1 end
+        if head.id == HLIST then -- hbox
+          rectangle.data = string.format("q %s %g w %g %g %g %g re s Q", 
+            params.hlist.color, rule_width, -rule_width / 2, -dp, wd, ht)
+        else
+          rectangle.data = string.format("q %s %g w %g %g %g %g re s Q", 
+            params.vlist.color, rule_width, -rule_width / 2, 0, wd, -ht)
+        end
+        head.list = node.insert_before(head.list,head.list,rectangle)
       end
-      head.list = node.insert_before(head.list,head.list,rectangle)
-
 
     elseif head.id == RULE and params.rule.show then
       local show_rule = node.new("whatsit","pdf_literal")

--- a/lua-visual-debug.lua
+++ b/lua-visual-debug.lua
@@ -65,51 +65,6 @@ local KERN = node.id("kern")
 local PENALTY = node.id("penalty")
 local GLYPH = node.id("glyph")
 
-local keyval = require('luakeyval')
-local process_keys = keyval.process
-local scan_bool = keyval.bool
-local scan_string = token.scan_string
-local scan_float = token.scan_float
-local inner_keys = {
-    hlist = {
-        show = {scanner = scan_bool},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float}
-    },
-    vlist = {
-        show = {scanner = scan_bool},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float}
-    },
-    rule = {
-        show = {scanner = scan_bool},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float}
-    },
-    disc = {
-        show = {scanner = scan_bool},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float}
-    },
-    glue = {
-        show = {scanner = scan_bool},
-    },
-    kern = {
-        show = {scanner = scan_bool},
-        negative_color = {scanner = scan_string},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float}
-    },
-    penalty = {
-        show = {scanner = scan_bool},
-    },
-    glyph = {
-        show = {scanner = scan_bool},
-        color = {scanner = scan_string},
-        width = {scanner = scan_float},
-        baseline = {scanner = scan_bool}
-    },
-}
 local params = {
     hlist = {show = true, color = "0.5 G", width = 0.1},
     vlist = {show = true, color = "0.1 G", width = 0.1},
@@ -120,43 +75,6 @@ local params = {
     penalty = {show = true},
     glyph = {show = false, color = "1 0 0 RG", width = 0.05, baseline = true},
 }
-
-local function set_params(key)
-    local vals = process_keys(inner_keys[key])
-    for k,v in pairs(vals) do
-        params[key][k] = v
-    end
-end
-
-local function onlyglyphs()
-    for _,v in pairs(params) do
-        v.show = false
-    end
-    params.glyph.show = true
-end
-
-local outer_keys = {
-    hlist = {scanner = function() return true end, func = set_params},
-    vlist = {scanner = function() return true end, func = set_params},
-    rule = {scanner = function() return true end, func = set_params},
-    disc = {scanner = function() return true end, func = set_params},
-    glue = {scanner = function() return true end, func = set_params},
-    kern = {scanner = function() return true end, func = set_params},
-    penalty = {scanner = function() return true end, func = set_params},
-    glyph = {scanner = function() return true end, func = set_params},
-    onlyglyphs = {default = true, func = onlyglyphs}
-}
-
-do
-  if token.is_defined('lvdset') then
-      texio.write_nl('log', "lua-visual-debug: redefining \\lvdset")
-  end
-  local function_table = lua.get_functions_table()
-  local luafnalloc = luatexbase and luatexbase.new_luafunction 
-    and luatexbase.new_luafunction('lvdset') or #function_table + 1
-  token.set_lua('lvdset', luafnalloc)
-  function_table[luafnalloc] = function() return process_keys(outer_keys) end
-end
 
 local function math_round(num, idp)
   if idp and idp>0 then
@@ -312,5 +230,6 @@ end
 
 
 return {
-  show_page_elements = show_page_elements
+  show_page_elements = show_page_elements,
+  params = params
 }

--- a/lua-visual-debug.sty
+++ b/lua-visual-debug.sty
@@ -14,7 +14,9 @@
 \ifx\ProvidesPackage\undefined
   \ifluatex
    \input atbegshi.sty\relax
-   \directlua{ lvd = require("lua-visual-debug")}
+   \directlua{
+     require("lua-visual-debug-keys")   
+     lvd = require("lua-visual-debug")}
    \AtBeginShipout {\directlua{lvd.show_page_elements(tex.box["AtBeginShipoutBox"])}}%
    \AtBeginShipoutInit
   \else
@@ -23,6 +25,7 @@
 \else
   \ifluatex
     \directlua{
+      require("lua-visual-debug-keys")
       local lvd = require("lua-visual-debug")
       luatexbase.add_to_callback('pre_shipout_filter', lvd.show_page_elements, 'lvd')
     }

--- a/lua-visual-debug.sty
+++ b/lua-visual-debug.sty
@@ -11,27 +11,23 @@
   \RequirePackage{ifluatex}
 \fi
 
-\def\luavisualdebug@dothings{%
-  \directlua{ lvd = require("lua-visual-debug")}%
-  \AtBeginShipout {\directlua{lvd.show_page_elements(tex.box["AtBeginShipoutBox"])}}%
-}
-
 \ifx\ProvidesPackage\undefined
   \ifluatex
    \input atbegshi.sty\relax
-   \luavisualdebug@dothings
+   \directlua{ lvd = require("lua-visual-debug")}
+   \AtBeginShipout {\directlua{lvd.show_page_elements(tex.box["AtBeginShipoutBox"])}}%
    \AtBeginShipoutInit
   \else
     \message{Warning: lua-visual-debug only works with LuaTeX (plain and LaTeX format)}
   \fi
 \else
   \ifluatex
-    \RequirePackage{atbegshi}
-    \luavisualdebug@dothings
+    \directlua{
+      local lvd = require("lua-visual-debug")
+      luatexbase.add_to_callback('pre_shipout_filter', lvd.show_page_elements, 'lvd')
+    }
   \else
     \PackageWarning{lua-visual-debug}{You are using this package without LuaTeX. This is not supported, so you don't get any visual debugging.}
   \fi
 \fi
-
-
 

--- a/luakeyval.lua
+++ b/luakeyval.lua
@@ -1,0 +1,117 @@
+-- luakeyval Version: 0.1, 2025-12-01
+
+local put_next = token.unchecked_put_next
+local get_next = token.get_next
+local scan_toks = token.scan_toks
+local scan_keyword = token.scan_keyword_cs
+
+local texerror, utfchar = tex.error, utf8.char
+local format = string.format
+
+-- local relax = token.new(token.biggest_char() + 1)
+local relax
+do
+-- initialization of the new primitives.
+  local prefix = '@lua^key&val_' -- unlikely prefix...
+  while token.is_defined(prefix .. 'relax') do
+    prefix = prefix .. '@lua^key&val_'
+  end
+  tex.enableprimitives(prefix,{'relax'})
+-- Now we create new tokens with the meaning of
+-- the primitives.
+  local tok = token.create(prefix .. 'relax')
+  relax = token.new(tok.mode, tok.command)
+end
+
+local function check_delimiter(error1, error2, key)
+    local tok = get_next()
+    if tok.tok ~= relax.tok then
+        local tok_name = tok.csname or utfchar(tok.mode)
+        texerror(format(error1, key, tok_name),{format(error2, key, tok_name)})
+        put_next({tok})
+    end
+end
+
+local unpack = table.unpack
+local function process_keys(keys, messages, order)
+    assert(type(keys) == 'table')
+    local matched, vals, curr_key = true, { }
+    messages = messages or { }
+    local value_forbidden = messages.value_forbidden
+        or 'luakeyval: The key "%s" does not accept a value'
+    local value_required = messages.value_required
+        or 'luakeyval: The key "%s" requires a value'
+    local error1 = messages.error1
+        or 'luakeyval: Wrong syntax when processing keys'
+    local error2 = messages.error2
+        or 'luakeyval: The last scanned key was "%s".\nUnexpected token "%s" encountered.'
+    local key_list = { }
+    if order then
+        for _, k in ipairs(order) do
+            key_list[#key_list+1] = k
+        end
+    else
+        for k in pairs(keys) do
+            key_list[#key_list+1] = k
+        end
+    end
+    local toks = scan_toks()
+    toks[#toks+1] = relax
+    put_next(toks)
+    while matched do
+        matched = false
+        for _, key in ipairs(key_list) do
+            local param = keys[key]
+            if scan_keyword(key) then
+                matched = true
+                curr_key = key
+                local args = param.args or { }
+                local scanner = param.scanner
+                local val
+                if scan_keyword('=') then
+                    if scanner then
+                        val = scanner(unpack(args))
+                    else
+                        texerror(format(value_forbidden, key))
+                    end
+                else
+                    val = param.default
+                    if val == nil then 
+                        texerror(format(value_required, key))
+                    end
+                end
+                local func = param.func
+                if func then func(key,val) end
+                vals[key] = val
+                break
+            end
+        end
+    end
+    check_delimiter(error1, error2, curr_key or '<none>')
+    return vals
+end
+
+local function scan_choice(...)
+    local choices = {...}
+    for _, choice in ipairs(choices) do
+        if scan_keyword(choice) then
+            return choice
+        end
+    end
+    return nil
+end
+
+local function scan_bool()
+    if scan_keyword('true') then 
+        return true
+    elseif scan_keyword('false') then
+        return false
+    end
+    return nil
+end
+
+return {
+    process = process_keys,
+    choices = scan_choice,
+    bool = scan_bool,
+}

--- a/lvdebug-doc.tex
+++ b/lvdebug-doc.tex
@@ -1,5 +1,5 @@
 \documentclass{article}
-\usepackage{graphicx,listings,lmodern,luatextra}
+\usepackage{graphicx,listings,lmodern,luatextra,booktabs}
 \newcommand\pkgversion{see Makefile}
 
 \newcommand*\pgsmall{\fontsize{8.5}{8.7}\selectfont\ttfamily}
@@ -47,7 +47,7 @@ When you load the package \texttt{lua-visual-debug} in your \LuaLaTeX\ document 
 
 \noindent\includegraphics[width=.9\textwidth]{lvdebugdetail1-num}
 \begin{enumerate}
-	\item A vertical glue. Beginning and end are marked with a small tick. At the mark 1, two vertical glues are connected.
+\item A vertical glue. Beginning and end are marked with a small tick. At the mark 1, two vertical glues are connected.
 \item A horizontal glue. Blue dashed lines represent stretched glues, magenta lines represent shrunk glues, gray at their natural width.
 \item A negative kern. Positive kerns are yellow.
 \item A possible hyphenation point.
@@ -61,6 +61,60 @@ A strut box (zero width box) is marked with a red rule:
 
 % section how_to_interpret_the_ (end)
 
+\newpage
+
+\section{Configuration}
+The \verb|\lvdset| macro modifies the markers described in Section~\ref{sec:how_to_interpret_the_markers}.
+It accepts a list of space-separated \texttt{key/val} pairs. Most keys accept nested \texttt{key/val} pairs 
+enclosed in curly braces.
+
+\medskip
+\noindent
+\begin{tabular}{@{}lllp{6cm}@{}}
+\toprule
+\textbf{Key} & \textbf{Sub-key} & \textbf{Default} & \textbf{Description} \\
+\midrule
+\texttt{hlist} & \texttt{show} & \texttt{true} & Whether to mark hlists \\
+               & \texttt{color} & \texttt{0.5 G} & PDF stroking color operator \\
+               & \texttt{width} & \texttt{0.1} & Line width in bp units \\
+\midrule
+\texttt{vlist} & \texttt{show} & \texttt{true} & Whether to mark vlists \\
+               & \texttt{color} & \texttt{0.1 G} & PDF stroking color operator \\
+               & \texttt{width} & \texttt{0.1} & Line width in bp units \\
+\midrule
+\texttt{rule} & \texttt{show} & \texttt{true} & Whether to mark rules \\
+              & \texttt{color} & \texttt{1 0 0 RG 1 0 0 rg} & PDF stroking color operator \\
+              & \texttt{width} & \texttt{0.4} & Line width in bp units \\
+\midrule
+\texttt{disc} & \texttt{show} & \texttt{true} & Whether to mark discretionaries \\
+              & \texttt{color} & \texttt{0 0 1 RG} & PDF stroking color operator \\
+              & \texttt{width} & \texttt{0.3} & Line width in bp units \\
+\midrule
+\texttt{glue} & \texttt{show} & \texttt{true} & Whether to mark glue \\
+\midrule
+\texttt{kern} & \texttt{show} & \texttt{true} & Whether to mark kerns \\
+              & \texttt{color} & \texttt{1 1 0 rg} & PDF color for positive kerns (stroke and fill) \\
+              & \texttt{negative\_color} & \texttt{1 0 0 rg} & PDF color for negative kerns (stroke and fill) \\
+              & \texttt{width} & \texttt{1} & Line width in bp units \\
+\midrule
+\texttt{penalty} & \texttt{show} & \texttt{true} & Whether to mark penalties \\
+\midrule
+\texttt{glyph} & \texttt{show} & \texttt{false} & Whether to mark glyphs \\
+               & \texttt{color} & \texttt{1 0 0 RG} & PDF stroking color operator \\
+               & \texttt{width} & \texttt{0.05} & Line width in bp units \\
+               & \texttt{baseline} & \texttt{true} & Whether to mark the baseline \\
+\midrule
+\texttt{onlyglyphs} & — & — & Shortcut to disable all markers except glyphs \\
+\bottomrule
+\end{tabular}
+
+\medskip
+\noindent
+\textit{Notes:} 
+\begin{itemize}
+\item The \texttt{kern} key uses both stroke and fill colors, unlike other keys which only use stroking color.
+\item The \texttt{onlyglyphs} key is a boolean flag (no value needed) that sets all \texttt{show} keys to \texttt{false} except \texttt{glyph/show}, which is set to \texttt{true}.
+\end{itemize}
 
 \section{Copying}
 

--- a/lvdebug-doc.tex
+++ b/lvdebug-doc.tex
@@ -84,7 +84,7 @@ must be enclosed in curly braces, e.g., \verb|\lvdset{glyph={color={1 0 0 RG}}}|
                & \texttt{width} & \texttt{0.1} & Line width in bp units \\
 \midrule
 \texttt{rule} & \texttt{show} & \texttt{true} & Whether to mark rules \\
-              & \texttt{color} & \texttt{1 0 0 RG 1 0 0 rg} & PDF stroking color operator \\
+              & \texttt{color} & \texttt{1 0 0 RG} & PDF stroking color operator \\
               & \texttt{width} & \texttt{0.4} & Line width in bp units \\
 \midrule
 \texttt{disc} & \texttt{show} & \texttt{true} & Whether to mark discretionaries \\
@@ -102,7 +102,7 @@ must be enclosed in curly braces, e.g., \verb|\lvdset{glyph={color={1 0 0 RG}}}|
 \midrule
 \texttt{glyph} & \texttt{show} & \texttt{false} & Whether to mark glyphs \\
                & \texttt{color} & \texttt{1 0 0 RG} & PDF stroking color operator \\
-               & \texttt{width} & \texttt{0.05} & Line width in bp units \\
+               & \texttt{width} & \texttt{0.1} & Line width in bp units \\
                & \texttt{baseline} & \texttt{true} & Whether to mark the baseline \\
 \midrule
 \texttt{onlyglyphs} & — & — & Shortcut to disable all markers except glyphs \\

--- a/lvdebug-doc.tex
+++ b/lvdebug-doc.tex
@@ -66,7 +66,8 @@ A strut box (zero width box) is marked with a red rule:
 \section{Configuration}
 The \verb|\lvdset| macro modifies the markers described in Section~\ref{sec:how_to_interpret_the_markers}.
 It accepts a list of space-separated \texttt{key/val} pairs. Most keys accept nested \texttt{key/val} pairs 
-enclosed in curly braces.
+enclosed in curly braces. PDF operators (for \texttt{color}, \texttt{negative\_color}, and \texttt{opacity}) 
+must be enclosed in curly braces, e.g., \verb|\lvdset{glyph={color={1 0 0 RG}}}|.
 
 \medskip
 \noindent
@@ -105,6 +106,8 @@ enclosed in curly braces.
                & \texttt{baseline} & \texttt{true} & Whether to mark the baseline \\
 \midrule
 \texttt{onlyglyphs} & — & — & Shortcut to disable all markers except glyphs \\
+\midrule
+\texttt{opacity} & — & (empty) & PDF graphics state operator for transparency \\
 \bottomrule
 \end{tabular}
 

--- a/lvdebug-doc.tex
+++ b/lvdebug-doc.tex
@@ -117,6 +117,7 @@ must be enclosed in curly braces, e.g., \verb|\lvdset{glyph={color={1 0 0 RG}}}|
 \begin{itemize}
 \item The \texttt{kern} key uses both stroke and fill colors, unlike other keys which only use stroking color.
 \item The \texttt{onlyglyphs} key is a boolean flag (no value needed) that sets all \texttt{show} keys to \texttt{false} except \texttt{glyph/show}, which is set to \texttt{true}.
+\item The \texttt{opacity} key applies to all node types. For fine-tuned opacity control per node type, the \texttt{color} keys can be (ab)used to include graphics state operators.
 \end{itemize}
 
 \section{Copying}


### PR DESCRIPTION
This commit is an attempt to add user interface
for configuration of some parameters such as
rule colors, widths and off/on logic per node
type.

It is using the luakeval module, a module which
is format agnostic, so it should work in plain
and LaTeX.

Some parameters are still not implemented.
Mostly options for kern, glue and penalty
should be refined, as they have colors for
different situations, so more keys needs to
be added.

In addition documentation should be updated.